### PR TITLE
added `dependencies = TRUE`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 To install the latest stable version from CRAN, use `install.packages`:
 
 ```R
-install.packages('BayesFactor')
+install.packages('BayesFactor', dependencies = TRUE)
 ```
 or your R graphical user interface's install packages menu.
 
@@ -17,7 +17,7 @@ install.packages('devtools')
 ## Load devtools package for install_github()
 library(devtools)
 ## get BayesFactor from github
-install_github('BayesFactor','richarddmorey', subdir='pkg/BayesFactor')
+install_github('BayesFactor','richarddmorey', subdir='pkg/BayesFactor', dependencies = TRUE)
 ```
 
 Under Linux, you'll need standard build tools installed (`gcc`, etc).


### PR DESCRIPTION
Seems that the vignettes require a bunch of packages I'd never heard of and the install failed several times in a row because I didn't have them, one after the other... It will simplify the package install if those other packages are installed all at once rather than going through the cycle of install bf -> install fails due to missing package -> install missing package -> attempt to install bf again -> install fails due to missing package etc.
