### PR TITLE
Fix to callback partial abortion issue

### DIFF
--- a/pkg/BayesFactor/R/common.R
+++ b/pkg/BayesFactor/R/common.R
@@ -366,3 +366,26 @@ sumWithPropErr <- function(x1,x2,err1,err2){
   propErr = exp(absSum - logSum)
   return(c(logSum,propErr))
 }
+
+BFtry <- function(expression, silent=FALSE) {
+
+  result <- base::try(expression, silent=silent)
+  
+  if (inherits(result, "try-error")) {
+  
+    message <- as.character(result)
+    split <- base::strsplit(as.character(message), " : ")[[1]]
+    error <- split[[length(split)]]
+
+    while (substr(error, 1, 1) == ' ' || substr(error, 1, 1) == '\n')  # trim front
+      error <- substring(error, 2)
+    
+    while (substring(error, nchar(error)) == ' ' || substring(error, nchar(error)) == '\n')  # trim back
+      error <- substr(error, 1, nchar(error)-1)
+    
+    if (error == "Operation cancelled by callback function.")
+      stop("Operation cancelled by callback function.")
+  }
+  
+  result
+}

--- a/pkg/BayesFactor/R/methods-BFlinearModel-compare.R
+++ b/pkg/BayesFactor/R/methods-BFlinearModel-compare.R
@@ -30,7 +30,7 @@ setMethod('compare', signature(numerator = "BFlinearModel", denominator = "missi
                     longName = paste("Intercept only", sep="")
                   )
     bf <- c(bf=NA, properror=NA)                 
-    try({
+    BFtry({
       if( nFactors == 0 ){
         numerator = denominator
         bf = c(bf = 0, properror = 0)

--- a/pkg/BayesFactor/R/nWayAOV-utility.R
+++ b/pkg/BayesFactor/R/nWayAOV-utility.R
@@ -29,7 +29,7 @@ singleGBayesFactor <- function(y,X,rscale,gMap,incCont){
         exp(Qg(log(g), ..., limit=FALSE) - log(g) - const)
       },"g")
     
-    integral = try({
+    integral = BFtry({
       op = optim(0, Qg, control=list(fnscale=-1),gr=dQg, method="BFGS",
                  sumSq=sumSq,N=N,XtCnX=XtCnX,CnytCnX=CnytCnX, rscale=rscale, gMap=gMap, gMapCounts=gMapCounts,priorX=priorX,incCont=incCont)
       const = op$value - op$par
@@ -58,16 +58,16 @@ doNwaySampling<-function(method, y, X, rscale, iterations, gMap, incCont, progre
   if(ncol(X)==1) method="simple"
   
   if(method=="auto"){
-    simpSamples = try(jzs_sampler(testNsamples, y, X, rscale, gMap, incCont, NA, NA, FALSE, testCallback, 1, 0))
+    simpSamples = BFtry(jzs_sampler(testNsamples, y, X, rscale, gMap, incCont, NA, NA, FALSE, testCallback, 1, 0))
     simpleErr = propErrorEst(simpSamples)
     logAbsSimpErr = logMeanExpLogs(simpSamples) + log(simpleErr) 
      
     
-    apx = suppressWarnings(try(gaussianApproxAOV(y,X,rscale,gMap,incCont)))
+    apx = suppressWarnings(BFtry(gaussianApproxAOV(y,X,rscale,gMap,incCont)))
     if(inherits(apx,"try-error")){
       method="simple"
     }else{
-      impSamples = try(jzs_sampler(testNsamples, y, X, rscale, gMap, incCont, apx$mu, apx$sig, FALSE, testCallback, 1, 1))
+      impSamples = BFtry(jzs_sampler(testNsamples, y, X, rscale, gMap, incCont, apx$mu, apx$sig, FALSE, testCallback, 1, 1))
       if(inherits(impSamples, "try-error")){
         method="simple"
       }else{
@@ -87,11 +87,11 @@ doNwaySampling<-function(method, y, X, rscale, iterations, gMap, incCont, progre
   if(method=="importance"){
 
     if(is.null(apx) | inherits(apx,"try-error"))  
-      apx = try(gaussianApproxAOV(y,X,rscale,gMap,incCont))
+      apx = BFtry(gaussianApproxAOV(y,X,rscale,gMap,incCont))
     if(inherits(apx, "try-error")){
       method="simple"   
     }else{
-      goodSamples= try(jzs_sampler(iterations, y, X, rscale, gMap, incCont, apx$mu, apx$sig, progress, callback, 1, 1))
+      goodSamples= BFtry(jzs_sampler(iterations, y, X, rscale, gMap, incCont, apx$mu, apx$sig, progress, callback, 1, 1))
       if(inherits(goodSamples,"try-error")){
         method="simple"
         goodSamples = NULL

--- a/pkg/BayesFactor/R/oneWayAOV_Fstat.R
+++ b/pkg/BayesFactor/R/oneWayAOV_Fstat.R
@@ -51,7 +51,7 @@ oneWayAOV.Fstat = function(F, N, J, rscale="medium", simple = FALSE)
 {
   rscale = rpriorValues("allNways","fixed",rscale)
   res = c(bf=NA, properror=NA)
-  try({
+  BFtry({
     log.const = marginal.g.oneWay(1,F=F,N=N,J=J,rscale=rscale,log=TRUE)
     integral = integrate(marginal.g.oneWay,lower=0,upper=Inf,F=F,N=N,J=J,rscale=rscale,log.const=log.const)
     properror = exp(log(integral[[2]]) - log(integral[[1]]))

--- a/pkg/BayesFactor/R/ttest_tstat.R
+++ b/pkg/BayesFactor/R/ttest_tstat.R
@@ -76,9 +76,9 @@ ttest.tstat=function(t,n1,n2=0,nullInterval=NULL,rscale="medium", complement=FAL
   log.marg.like.0= -(nu+1)/2 * log(1+t^2/(nu))
   res = c(bf=NA, properror=NA)
   if(is.null(nullInterval)){
-    try({res = meta.t.bf(t,n,nu,rscale=rscale)})
+    BFtry({res = meta.t.bf(t,n,nu,rscale=rscale)})
   }else{
-    try({res = meta.t.bf(t,n,nu,interval=nullInterval,rscale=rscale,complement = complement)})
+    BFtry({res = meta.t.bf(t,n,nu,interval=nullInterval,rscale=rscale,complement = complement)})
   }
   if(simple){
     return(c(B10=exp(res$bf)))


### PR DESCRIPTION
I've replaced all calls to `try()` in the package to `BFtry()`

`BFtry()` behaves exactly like `try()` however, it aborts in the case of a callback abortion

Fixes #52