### PR TITLE
.gitignore tweaks + added .Rproj

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,15 @@
-# Compiled source #
-###################
+
+/pkg/*
+!/pkg/BayesFactor/
+!/pkg/BayesFactor/**/*
+
+/www/
+
+.DS_Store
+.Rproj.user
+.Rhistory
+.RData
+
 *.com
 *.class
 *.dll
@@ -7,49 +17,5 @@
 *.o
 *.so
 *.rds
-
-# /
-/.Rproj.user
-/.Rhistory
-/.RData
-/bayesfactorpcl.Rproj
-/core
-
-# /pkg/
-/pkg/BayesFactor_0.8.7.tgz
-
-# /pkg/BayesFactorPCL/
-/pkg/BayesFactorPCL/src-x86_64
-/pkg/BayesFactorPCL/src-i386
-
-# /pkg/BayesFactorPCL/R/
-/pkg/BayesFactorPCL/R/nWayGibi.Rold
-/pkg/BayesFactorPCL/R/oneWayGibi.Rold
-/pkg/BayesFactorPCL/R/eqVar.Rold
-
-# /pkg/BayesFactorPCL/inst/
-/pkg/BayesFactorPCL/inst/
-
-# /pkg/BayesFactorPCL/src/
-/pkg/BayesFactorPCL/src/BayesFactor.dll
-/pkg/BayesFactorPCL/src/symbols.rds
-
-# /pkg/BayesSingleSub/
-/pkg/BayesSingleSub/src-x86_64
-/pkg/BayesSingleSub/src-i386
-
-# /pkg/Gibi/inst/rsp/
-/pkg/Gibi/inst/rsp/gibi
-
-# /www/
-/www/testBayesFactor.html
-/www/testBayesFactor.md
-/www/figure
-/www/workshop.md
-/www/glmtest.html
-/www/glmtest.md
-.Rproj.user
-
-*.Rproj
-
-pkg/BayesFactor_0.9.6.tar.gz
+*.tar.gz
+*.tgz

--- a/pkg/BayesFactor/BayesFactor.Rproj
+++ b/pkg/BayesFactor/BayesFactor.Rproj
@@ -1,0 +1,20 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source


### PR DESCRIPTION
hey,

the lines:

```
/pkg/*
!/pkg/BayesFactor/
!/pkg/BayesFactor/**/*
```

ignores everything in `pkg` that isn't `BayesFactor`, this should serve the same function as a lot of your custom rules (the 'unignore' of `pkg/BayesFactor/**/*` also means i've had to shift the extension ignores to the bottom).

i've also added a .Rproj file, because this makes it easy for contributors (myself) to use the correct indentation level, etc.