### PR TITLE
Added support for special chars (spaces, etc.) in column names

### DIFF
--- a/pkg/BayesFactor/R/anovaBF-utility.R
+++ b/pkg/BayesFactor/R/anovaBF-utility.R
@@ -12,6 +12,7 @@ enumerateAnovaModels = function(fmla, whichModels, data){
   trms <- attr(terms(fmla, data = data), "term.labels")
   ntrms <- length(trms)
   dv = stringFromFormula(fmla[[2]])
+  dv = composeTerm(dv)
   if(ntrms == 1 ) whichModels = "all"
 
   if(whichModels=="top"){
@@ -37,10 +38,11 @@ enumerateAnovaModels = function(fmla, whichModels, data){
 
 createFixedAnovaModel <- function(dataTypes, formula){
   fixedFactors <- names(dataTypes[dataTypes=="fixed"])
-  fixedPart <- paste(fixedFactors,collapse="*")
+  fixedPart <- paste(composeTerms(fixedFactors),collapse="*")
 
   # get LHS of formula
   dv = stringFromFormula(formula[[2]])
+  dv = composeTerm(dv)
 
   formula(paste(dv, "~", fixedPart, collapse=""))
 }
@@ -51,6 +53,7 @@ addRandomModelPart <- function(formula, dataTypes, null = FALSE){
 
   fmla = stringFromFormula(formula)
   dv = stringFromFormula(formula[[2]])
+  dv = composeTerm(dv)
   if(null){
     ret = formula(paste(dv, "~", randomPart, collapse=""))
   }else{

--- a/pkg/BayesFactor/R/base64.R
+++ b/pkg/BayesFactor/R/base64.R
@@ -1,0 +1,171 @@
+
+# Author: Jonathon Love
+
+toB64Lookup <- c(
+  0x41,   # A
+  0x42,   # B
+  0x43,   # C
+  0x44,   # D
+  0x45,   # E
+  0x46,   # F
+  0x47,   # G
+  0x48,   # H
+  0x49,   # I
+  0x4A,   # J
+  0x4B,   # K
+  0x4C,   # L
+  0x4D,   # M
+  0x4E,   # N
+  0x4F,   # O
+  0x50,   # P
+  0x51,   # Q
+  0x52,   # R
+  0x53,   # S
+  0x54,   # T
+  0x55,   # U
+  0x56,   # V
+  0x57,   # W
+  0x58,   # X
+  0x59,   # Y
+  0x5A,   # Z
+  0x61,   # a
+  0x62,   # b
+  0x63,   # c
+  0x64,   # d
+  0x65,   # e
+  0x66,   # f
+  0x67,   # g
+  0x68,   # h
+  0x69,   # i
+  0x6A,   # j
+  0x6B,   # k
+  0x6C,   # l
+  0x6D,   # m
+  0x6E,   # n
+  0x6F,   # o
+  0x70,   # p
+  0x71,   # q
+  0x72,   # r
+  0x73,   # s
+  0x74,   # t
+  0x75,   # u
+  0x76,   # v
+  0x77,   # w
+  0x78,   # x
+  0x79,   # y
+  0x7A,   # z
+  0x30,   # 0
+  0x31,   # 1
+  0x32,   # 2
+  0x33,   # 3
+  0x34,   # 4
+  0x35,   # 5
+  0x36,   # 6
+  0x37,   # 7
+  0x38,   # 8
+  0x39,   # 9
+  0x2E,   # .
+  0x5F)   # _
+
+fromB64Lookup <- c(
+  rep(-1, 0x2D),
+  63,
+  -1,
+  0x35:0x3E,  # 0x30
+  rep(-1, 0x40 - 0x3A + 1),
+  1:26,  # 0x41
+  rep(-1, 0x5E - 0x5B + 1), # 0x5B
+  64, # 0x5F
+  -1, # 0x60
+  1:26+26,
+  rep(-1, 0x7F - 0x7A + 1))
+
+toB64 <- function(names) {
+  sapply(names, toB64string, USE.NAMES=FALSE)
+}
+
+fromB64 <- function(names) {
+  sapply(names, fromB64string, USE.NAMES=FALSE)
+}
+
+fromB64string <- function(string) {
+
+  if ( ! startsWith(x, '.'))
+    stop('b64 names should begin with a dot')
+
+  string <- substring(string, 2)
+
+  if (string == "")
+    return("")
+
+  array <- as.integer(charToRaw(string))
+  array <- fromB64Lookup[array] - 1
+
+  out <- c()
+
+  i <- 1
+  j <- 1
+
+  while (i <= length(array)) {
+
+    if (i + 1 <= length(array))
+      out[j + 0] <- 4  *  array[i + 0] + floor(array[i + 1] / 16)
+    else
+      out[j + 0] <- 4  *  array[i + 0]
+
+    if (i + 2 <= length(array))
+      out[j + 1] <- 16 * (array[i + 1] %% 16) + as.integer(array[i + 2] / 4)
+    if (i + 3 <= length(array))
+      out[j + 2] <- 64 * (array[i + 2] %% 4) + array[i + 3]
+
+    i <- i + 4
+    j <- j + 3
+  }
+
+  rawToChar(as.raw(out))
+}
+
+
+toB64string <- function(string) {
+
+  if (string == "")
+    return("")
+
+  array <- as.integer(charToRaw(string))
+
+  out <- c()
+
+  i <- 1
+  j <- 1
+
+  while (i <= length(array)) {
+
+    out[j + 0] <- floor(array[i + 0] / 4)
+
+    if (i + 1 <= length(array)) {
+
+      out[j + 1] <- (array[i + 0] %% 4) * 16 + floor((array[i + 1] / 16))
+
+      if (i + 2 <= length(array)) {
+
+        out[j + 2] <- (array[i + 1] %% 16) * 4 + floor(array[i + 2] / 64)
+        out[j + 3] <- array[i + 2] %% 64
+      }
+      else {
+
+        out[j + 2] <- (array[i + 1] %% 16) * 4
+      }
+    }
+    else {
+
+      out[j + 1] <- (array[i + 0] %% 4) * 16
+    }
+
+    i <- i + 3
+    j <- j + 4
+  }
+
+  chars <- toB64Lookup[out + 1]
+
+  paste0('.', rawToChar(as.raw(chars)))
+}

--- a/pkg/BayesFactor/R/generalTest-utility.R
+++ b/pkg/BayesFactor/R/generalTest-utility.R
@@ -34,6 +34,8 @@ enumerateGeneralModels = function(fmla, whichModels, neverExclude=NULL, includeB
 
   ntrms <- length(trms)
   dv = stringFromFormula(fmla[[2]])
+  dv = composeTerm(dv)
+
   if(ntrms == 0 )  return(list(fmla))
   if(ntrms == 1 ) whichModels = "all"
 
@@ -100,7 +102,7 @@ possibleRestrictionsWithMainGeneralFallback <- function(trms, alwaysKept){
 
 possibleRestrictionsWithMainGeneral <- function(trms, alwaysKept=NULL){
   if(length(trms)==1) return(list(trms))
-  myFactors = unique(unlist(strsplit(trms,":",fixed=TRUE)))  
+  myFactors = unique(unlist(decomposeTerms(trms)))
   nFactors = length(myFactors)
 
   # If there are more than 5 factors involved then the total number of models is

--- a/pkg/BayesFactor/R/methods-BFlinearModel-compare.R
+++ b/pkg/BayesFactor/R/methods-BFlinearModel-compare.R
@@ -22,6 +22,7 @@ setMethod('compare', signature(numerator = "BFlinearModel", denominator = "missi
     relevantDataTypes = dataTypes[names(dataTypes) %in% factors]
 
     dv = stringFromFormula(formula[[2]])
+    dv = composeTerm(dv)
     if(numerator@type != "JZS") stop("Unknown model type.")
 
     denominator = BFlinearModel(type = "JZS",

--- a/pkg/BayesFactor/R/methods-BFmodel.R
+++ b/pkg/BayesFactor/R/methods-BFmodel.R
@@ -191,6 +191,7 @@ setMethod('compare', signature(numerator = "BFindepSample", denominator = "missi
             checkFormula(formula, data, analysis = "indept")
 
             dv = stringFromFormula(formula[[2]])
+            dv = composeTerm(dv)
             factor = fmlaFactors(formula, data)[-1]
 
             y = data[[dv]]

--- a/pkg/BayesFactor/R/methods-BFmodelSample.R
+++ b/pkg/BayesFactor/R/methods-BFmodelSample.R
@@ -93,6 +93,7 @@ setMethod('posterior', signature(model = "BFlinearModel", index = "missing", dat
     relevantDataTypes = dataTypes[names(dataTypes) %in% factors]
 
     dv = stringFromFormula(formula[[2]])
+    dv = composeTerm(dv)
     if(model@type != "JZS") stop("Unknown model type.")
 
     if( nFactors == 0 ){

--- a/pkg/BayesFactor/R/nWayAOV-utility.R
+++ b/pkg/BayesFactor/R/nWayAOV-utility.R
@@ -333,12 +333,16 @@ fixedFromRandomProjection <- function(nlevRandom, sparse = FALSE){
 }
 
 centerContinuousColumns <- function(data){
-  for (colName in colnames(data)) {
-    column <- data[[colName]]
-    if ( ! is.factor(column))
-      data[[colName]] = column - mean(column)
-  }
-  data
+  mycols = lapply(data,function(colmn){
+    if(is.factor(colmn)){
+      return(colmn)
+    }else{
+      return(colmn - mean(colmn))
+    }
+  })
+  df <- data.frame(mycols)
+  colnames(df) <- colnames(data)
+  return(df)
 }
 
 nWayFormula <- function(formula, data, dataTypes, rscaleFixed=NULL, rscaleRandom=NULL, rscaleCont=NULL, rscaleEffects = NULL, posterior=FALSE, columnFilter = NULL, unreduce=TRUE, ...){

--- a/pkg/BayesFactor/R/regressionBF-utility.R
+++ b/pkg/BayesFactor/R/regressionBF-utility.R
@@ -2,6 +2,7 @@ enumerateRegressionModels = function(fmla, whichModels, data){
   trms <- attr(terms(fmla, data = data), "term.labels")
   ntrms <- length(trms)
   dv = stringFromFormula(fmla[[2]])
+  dv = composeTerm(dv)
   if(ntrms == 1 ) whichModels = "all"
 
   if(whichModels=="top"){
@@ -24,8 +25,10 @@ enumerateRegressionModels = function(fmla, whichModels, data){
 
 createFullRegressionModel <- function(formula, data){
   factors = fmlaFactors(formula, data)[-1]
+  factors = composeTerms(factors)
 
   dv = stringFromFormula(formula[[2]])
+  dv = composeTerm(dv)
 
   RHS = paste(factors,collapse=" + ")
   strng = paste(dv, " ~ ", RHS, collapse = "")

--- a/pkg/BayesFactor/inst/tests/test-generalTestBF.R
+++ b/pkg/BayesFactor/inst/tests/test-generalTestBF.R
@@ -4,5 +4,7 @@ context('generalTestBF')
 data(puzzles)
 
 test_that('generalTestBF works', {
-  generalTestBF(RT ~ shape*color*ID, whichRandom="ID", data = puzzles)
+  bf <- generalTestBF(RT ~ shape*color*ID, whichRandom="ID", data = puzzles)
+  expect_that(bf, is_a("BFBayesFactor"))
+  expect_that(length(bf), is_equivalent_to(18))
 })

--- a/pkg/BayesFactor/inst/tests/test-regressionBF.R
+++ b/pkg/BayesFactor/inst/tests/test-regressionBF.R
@@ -8,5 +8,16 @@ test_that("regressionBF works", {
   a <- rnorm(100)
   y <- x + a + rnorm(100)
   data <- data.frame(y, x, a)
-  regressionBF(y ~ x * a, data)
+  regressionBF(y ~ x + a, data)
+})
+
+test_that("regressionBF errors appropriately", {
+  x <- rnorm(100)
+  a <- rnorm(100)
+  y <- x + a + rnorm(100)
+  data <- data.frame(y, x, a)
+  expect_error(
+    regressionBF(y ~ x * a, data),
+    'Interactions not allowed in regressionBF (try generalTestBF)',
+    fixed=TRUE)
 })

--- a/pkg/BayesFactor/inst/tests/test-specialchars.R
+++ b/pkg/BayesFactor/inst/tests/test-specialchars.R
@@ -1,0 +1,55 @@
+
+context('special chars')
+
+e <- function(x) composeTerm(paste0(x, ' :`"\''))
+p <- paste0
+
+data('ToothGrowth')
+ToothGrowth$dose <- as.factor(ToothGrowth$dose)
+colnames(ToothGrowth) <- paste0(colnames(ToothGrowth), ' :`"\'')
+
+test_that('ttestBF accepts column names with special chars', {
+  formula <- p(e('len'), '~', e('supp'))
+  formula <- as.formula(formula)
+  results <- ttestBF(formula=formula, data=ToothGrowth)
+  expect_that(results, is_a("BFBayesFactor"))
+  expect_that(length(results), is_equivalent_to(1))
+})
+
+test_that('anovaBF accepts column names with special chars', {
+  formula <- p(e('len'), '~', e('supp'))
+  formula <- as.formula(formula)
+  results <- anovaBF(formula=formula, data=ToothGrowth)
+  expect_that(results, is_a("BFBayesFactor"))
+  expect_that(length(results), is_equivalent_to(1))
+
+  formula <- p(e('len'), '~', e('supp'), '*', e('dose'))
+  formula <- as.formula(formula)
+  results <- anovaBF(formula=formula, data=ToothGrowth)
+  expect_that(results, is_a("BFBayesFactor"))
+  expect_that(length(results), is_equivalent_to(4))
+})
+
+test_that('generalTestBF accepts column names with special chars', {
+  data(puzzles)
+  names(puzzles) <- paste0(colnames(puzzles), ' :`"\'')
+  formula <- p(e('RT'), '~', e('shape'), '*', e('color'), '*', e('ID'))
+  formula <- as.formula(formula)
+  bf <- generalTestBF(formula, whichRandom=e('ID'), data = puzzles)
+  expect_that(bf, is_a("BFBayesFactor"))
+  expect_that(length(bf), is_equivalent_to(18))
+})
+
+test_that("regressionBF accepts column names with special chars", {
+  set.seed(0)
+  x <- rnorm(100)
+  a <- rnorm(100)
+  y <- x + a + rnorm(100)
+  data <- data.frame(y, x, a)
+  colnames(data) <- paste0(colnames(data), ' :`"\'')
+  formula <- as.formula(p(e('y'), '~', e('x'), '+', e('a')))
+  bf <- regressionBF(formula, data)
+  expect_that(bf, is_a("BFBayesFactor"))
+  expect_that(length(bf), is_equivalent_to(3))
+})
+


### PR DESCRIPTION
hi rich,

this commit adds support for special chars, spaces, etc. in formulas and column names. the meat and potatoes of this is the `composeTerm()` and `composeTerms()` functions, which appropriately escape names for use in formulas.

i've also had to add some base64 code, because the `model.Matrix()` function does not support special chars either (and i haven't had good success with getting in touch with the authors of that package).

you'll see in `test-specialchars.R` all the cases i test. i think that's all of the relevant code paths, but it's possible you might know of a couple that i've missed (either way, there's little chance of a regression, so it's not critical that everything is spot-on in this commit ... although that's always nice)